### PR TITLE
Use https for TaxonomyTree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "TaxonomyTree"]
 	path = TaxonomyTree
-	url = git://github.com/rdpstaff/TaxonomyTree
+	url = https://github.com/rdpstaff/TaxonomyTree
 [submodule "SequenceMatch"]
 	path = SequenceMatch
 	url = https://github.com/rdpstaff/SequenceMatch.git


### PR DESCRIPTION
I ran into a problem today cloning RDPTools and updating the submodules while at a location where outgoing SSH traffic was blocked. While the other submodules cloned fine, `TaxonomyTools` hung indefinitely and was unable to be cloned. Changing the URL for the `TaxonomonyTree` submodule to match the other submodules using `https` alleviated the problem.